### PR TITLE
Export webui IP to variable to facilitate copy-pasting

### DIFF
--- a/docs/tutorial/03_configure_sdcore.md
+++ b/docs/tutorial/03_configure_sdcore.md
@@ -21,13 +21,19 @@ webui/0*              active    idle   10.1.19.189
 
 ```{note}
 Here the address is `10.1.19.189`, yours will likely be different. Make sure to replace it in
-the next commands.
+the next command.
+```
+
+Export your `webui` IP address to a variable:
+
+```console
+export WEBUI_IP="10.1.19.189"
 ```
 
 Create a new subscriber:
 
 ```console
-curl -v --location '10.1.19.189:5000/api/subscriber/imsi-208930100007487' \
+curl -v ${WEBUI_IP}:5000/api/subscriber/imsi-208930100007487 \
 --header 'Content-Type: text/plain' \
 --data '{
     "UeId":"208930100007487",
@@ -41,7 +47,7 @@ curl -v --location '10.1.19.189:5000/api/subscriber/imsi-208930100007487' \
 Create a new device group named "cows" that contains the newly created subscriber:
 
 ```console
-curl -v --location '10.1.19.189:5000/config/v1/device-group/cows' \
+curl -v ${WEBUI_IP}:5000/config/v1/device-group/cows \
 --header 'Content-Type: application/json' \
 --data '{
     "imsis": [
@@ -72,7 +78,7 @@ curl -v --location '10.1.19.189:5000/config/v1/device-group/cows' \
 Create a network slice called "default" that contains the "cows" device group:
 
 ```console
-curl -v --location '10.1.19.189:5000/config/v1/network-slice/default' \
+curl -v ${WEBUI_IP}:5000/config/v1/network-slice/default \
 --header 'Content-Type: application/json' \
 --data '{
   "slice-id": {


### PR DESCRIPTION
# Description

Add a small step to export the `webui` to a variable to facilitate copy-pasting of the `curl` commands.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
