### PR TITLE
Separating enabling of Microk8s plugins

### DIFF
--- a/docs/tutorial/02_deploy_sdcore.md
+++ b/docs/tutorial/02_deploy_sdcore.md
@@ -14,7 +14,8 @@ Enable the Multus and MetalLB MicroK8s addons. We must give MetalLB an address
 range that has at least 3 IP addresses for Charmed 5G.
 
 ```console
-sudo microk8s enable multus metallb:10.0.0.2-10.0.0.4
+sudo microk8s enable multus
+sudo microk8s enable metallb:10.0.0.2-10.0.0.4
 ```
 
 ## Deploy the `sdcore` charm bundle


### PR DESCRIPTION
# Description

Separates commands enabling Microk8s plugins. Enabling multiple plugins at once is discouraged and will be deprecated.
```shell
WARNING: Do not enable or disable multiple addons in one command.
         This form of chained operations on addons will be DEPRECATED in the future.
         Please, enable one addon at a time: 'microk8s enable <addon>'
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
