### PR TITLE
feat: Standardises section naming and ordering

### DIFF
--- a/docs/how-to/deploy_sdcore_cups.md
+++ b/docs/how-to/deploy_sdcore_cups.md
@@ -1,6 +1,6 @@
-# Deploy SD-Core with CUPS
+# Deploy SD-Core with Control Plane and User Plane Separation
 
-This guide covers how to install a multi-node SD-Core with Control Plane and User Plane Separation (CUPS).
+This guide covers how to install a SD-Core 5G core network with Control Plane and User Plane Separation (CUPS).
 
 ## Requirements
 

--- a/docs/how-to/deploy_sdcore_gnbsim.md
+++ b/docs/how-to/deploy_sdcore_gnbsim.md
@@ -1,6 +1,6 @@
-# Deploy ONF gNB Simulator
+# Deploy SD-Core gNB Simulator
 
-This guide covers how to install and configure the ONF gNB Simulator.
+This guide covers how to install and configure the SD-Core gNB Simulator.
 
 ## Requirements
 

--- a/docs/how-to/deploy_sdcore_standalone.md
+++ b/docs/how-to/deploy_sdcore_standalone.md
@@ -1,6 +1,6 @@
-# Deploy SD-Core
+# Deploy SD-Core Standalone
 
-This guide covers how to install a single node sdcore, suitable for lab or proof of concept purposes.
+This guide covers how to install a standalone SD-Core 5G core network, suitable for lab or proof of concept purposes.
 
 ## Requirements
 
@@ -20,4 +20,3 @@ juju deploy sdcore --trust --channel=edge
 ## Configure
 
 To view all configuration options, please visit the bundle's [Charmhub page](https://charmhub.io/sdcore/).
-

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -5,8 +5,8 @@ These how-to guides cover key operations and processes in Charmed 5G.
 ```{toctree}
 :maxdepth: 1
 
-deploy_cups_sdcore
-deploy_gnbsim
-deploy_sdcore
+deploy_sdcore_standalone
+deploy_sdcore_cups
+deploy_sdcore_gnbsim
 integrate_sdcore_with_observability
 ```

--- a/docs/reference/networking.md
+++ b/docs/reference/networking.md
@@ -1,4 +1,4 @@
-# 5G Network Architecture
+# Networking
 
 5G was built with network functions divided by services which is known as the 5G core Service-Based Architecture (SBA). The 5G core is a network of interconnected services, as illustrated in the figure below.
 
@@ -14,7 +14,6 @@ UPF Interfaces/reference points with employed protocols:
 - Access (N3): Interface between the RAN (gNB) and the UPF
 - Core (N6): Interface between the Data Network (DN) and the UPF
 - K8s LoadBalancer (N4): Interface between the Session Management Function (SMF) and the UPF  
-
 
 Connectivity between Control Plane and User Plane:
 


### PR DESCRIPTION
# Description

This PR standardises section naming and ordering. It removes the acronym "CUPS" from top level navigation.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
