### PR TITLE
fix: Fix QoS bitrate missing unit in tutorial

### DIFF
--- a/docs/tutorial/03_configure_sdcore.md
+++ b/docs/tutorial/03_configure_sdcore.md
@@ -63,6 +63,7 @@ curl -v ${WEBUI_IP}:5000/config/v1/device-group/cows \
         "ue-dnn-qos": {
             "dnn-mbr-uplink": 20000000,
             "dnn-mbr-downlink": 200000000,
+            "bitrate-unit": "bps",
             "traffic-class": {
                 "name": "platinum",
                 "arp": 6,


### PR DESCRIPTION
# Description

QoS bitrate was previously ignored if unit was not provided.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
