### PR TITLE
fix: Removes plmnid parameter from subscriber creation

### DIFF
--- a/docs/tutorial/03_configure_sdcore.md
+++ b/docs/tutorial/03_configure_sdcore.md
@@ -37,7 +37,6 @@ curl -v ${WEBUI_IP}:5000/api/subscriber/imsi-208930100007487 \
 --header 'Content-Type: text/plain' \
 --data '{
     "UeId":"208930100007487",
-    "plmnId":"20801",
     "opc":"981d464c7c52eb6e5036234984ad0bcf",
     "key":"5122250214c33e723a5dd523fc145fc0",
     "sequenceNumber":"16f3b3f70fc2"


### PR DESCRIPTION
# Description

fix: Removes plmnid parameter from subscriber creation.
The parameter is not used by the webui when creating a subscriber, it is calculated later using mcc and mnc

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
