### PR TITLE
feat: Add backup and restore procedures

### DIFF
--- a/docs/how-to/backup_sdcore.md
+++ b/docs/how-to/backup_sdcore.md
@@ -1,0 +1,25 @@
+# Backup SD-Core
+
+Backups of SD-Core are managed through the `mongodb-k8s` charm. This guide
+highlights the steps required by referencing that charm's documentation.
+
+## Integrate Mongo with S3
+
+`mongodb-k8s` saves backup to S3 compatible storage. The first step is to
+[configure S3 storage](https://charmhub.io/mongodb-k8s/docs/h-configure-s3?channel=5/edge).
+
+## Save the cluster password
+
+The restore procedure currently only works with a full redeployment. For this
+reason, the Mongo cluster password will be required.
+
+```bash
+juju run mongodb-k8s/leader get-password
+```
+
+Save the password in a safe place.
+
+## Create and list backups
+
+`mongodb-k8s` is now ready to
+[create and list backups](https://charmhub.io/mongodb-k8s/docs/h-create-and-list-backups?channel=5/edge).

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -11,4 +11,5 @@ deploy_sdcore_gnbsim
 integrate_sdcore_with_observability
 enable_hugepages_for_upf
 backup_sdcore
+restore_sdcore
 ```

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -10,4 +10,5 @@ deploy_sdcore_cups
 deploy_sdcore_gnbsim
 integrate_sdcore_with_observability
 enable_hugepages_for_upf
+backup_sdcore
 ```

--- a/docs/how-to/restore_sdcore.md
+++ b/docs/how-to/restore_sdcore.md
@@ -1,0 +1,41 @@
+# Restore SD-Core
+
+Restoring SD-Core from a backup currently requires a full redeployment of the
+control plane. This guide lays out the steps required to successfully restore
+from a backup.
+
+## Destroy previous control plane model
+
+If the control plane was deployed to a model named `core`, it will need to
+first be completely removed:
+
+```bash
+juju destroy-model --destroy-storage --force --no-wait core
+```
+
+## Recreate the model
+
+```bash
+juju add-model core
+```
+
+## Deploy `mongodb-k8s`
+
+```bash
+juju deploy mongodb-k8s --channel 5/edge
+```
+
+## Follow the restore procedure
+
+Use this [procedure](https://charmhub.io/mongodb-k8s/docs/h-migrate-cluster-via-restore?channel=5/edge)
+to restore the backup.
+
+## Redeploy the bundle
+
+Use the same steps you used for the initial deployment to redeploy the bundle.
+For example, if you deployed the complete SD-Core bundle, you would use the
+following command:
+
+```bash
+juju deploy sdcore --trust --channel=edge
+```


### PR DESCRIPTION
# Description

Add backup and restore procedures, referring to `mongodb-k8s` documentation as much as possible. This procedure currently only works as a disaster recovery procedure, requiring a full redeployment of SD-Core.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
