### PR TITLE
fix: Fixing typo in tutorial

### DIFF
--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -172,7 +172,7 @@ The output should be `http://core-nms.mynetwork.com/`. Navigate to this address 
 
 ## 6. Configure the 5G core network through the Network Management System
 
-In the Network Management System (NMS), create a device group with the following attributes:
+In the Network Management System (NMS), create a network slice with the following attributes:
 
 - Name: `default`
 - MCC: `208`


### PR DESCRIPTION
# Description

Replaces `device group` with `network slice`.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
