### PR TITLE
chore: update default device group name

### DIFF
--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -193,7 +193,7 @@ Create a subscriber with the following attributes:
 - Key: `5122250214c33e723a5dd523fc145fc0`
 - Sequence Number: `16f3b3f70fc2`
 - Network Slice: `default`
-- Device Group: `default`
+- Device Group: `default-default`
 
 You should see the following subscriber created:
 


### PR DESCRIPTION
# Description

Align docs to this change: https://github.com/canonical/sdcore-nms/pull/226

The name of the default Device Group Created when a Network Slice is created is no longer `default`. It includes the network slice name in it

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
