### PR TITLE
chore: Rename SD-Core charms and bundles by adding -k8s as a suffix

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -61,6 +61,7 @@ RAN
 Rockcraft
 Ryzen
 sdcore
+sdcore-k8s
 SMF
 TLS
 Traefik

--- a/docs/how-to/deploy_sdcore_cups.md
+++ b/docs/how-to/deploy_sdcore_cups.md
@@ -36,7 +36,7 @@ juju add-model control-plane control-plane-cloud
 
 Deploy the control plane bundle.
 ```console
-juju deploy sdcore-control-plane --trust --channel=edge --overlay control-plane-overlay.yaml
+juju deploy sdcore-control-plane-k8s --trust --channel=edge --overlay control-plane-overlay.yaml
 ```
 
 Expose the integration offer for the AMF N2 interface. 
@@ -73,5 +73,5 @@ juju add-model user-plane user-plane-cloud
 Deploy the user plane bundle.
 
 ```console
-juju deploy sdcore-user-plane --trust --channel=edge --overlay upf-overlay.yaml
+juju deploy sdcore-user-plane-k8s --trust --channel=edge --overlay upf-overlay.yaml
 ```

--- a/docs/how-to/deploy_sdcore_gnbsim.md
+++ b/docs/how-to/deploy_sdcore_gnbsim.md
@@ -17,10 +17,10 @@ Create a Juju model.
 juju add-model gnbsim gnbsim-cloud
 ```
 
-Deploy the `sdcore-gnbsim` operator charm.
+Deploy the `sdcore-gnbsim-k8s` operator charm.
 
 ```console
-juju deploy sdcore-gnbsim gnbsim --trust --channel=edge \
+juju deploy sdcore-gnbsim-k8s gnbsim --trust --channel=edge \
   --config gnb-interface=ran \
   --config gnb-ip-address=10.204.0.10/24 \
   --config icmp-packet-destination=8.8.8.8 \

--- a/docs/how-to/deploy_sdcore_standalone.md
+++ b/docs/how-to/deploy_sdcore_standalone.md
@@ -14,9 +14,9 @@ You will need a Kubernetes cluster installed and configured with Multus.
 ## Deploy
 
 ```bash
-juju deploy sdcore --trust --channel=edge
+juju deploy sdcore-k8s --trust --channel=edge
 ```
 
 ## Configure
 
-To view all configuration options, please visit the bundle's [Charmhub page](https://charmhub.io/sdcore/).
+To view all configuration options, please visit the bundle's [Charmhub page](https://charmhub.io/sdcore-k8s/).

--- a/docs/how-to/integrate_sdcore_with_observability.md
+++ b/docs/how-to/integrate_sdcore_with_observability.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- One of the `sdcore` bundles deployed in a Juju model
+- One of the `sdcore-k8s` bundles deployed in a Juju model
 
 ## Deploy the `cos-lite` bundle
 

--- a/docs/how-to/restore_sdcore.md
+++ b/docs/how-to/restore_sdcore.md
@@ -37,5 +37,5 @@ For example, if you deployed the complete SD-Core bundle, you would use the
 following command:
 
 ```bash
-juju deploy sdcore --trust --channel=edge
+juju deploy sdcore-k8s --trust --channel=edge
 ```

--- a/docs/reference/charms.md
+++ b/docs/reference/charms.md
@@ -2,20 +2,20 @@
 
 Configuration options and specific charm usage instructions are available on each charm's CharmHub page.
 
-| **Charm**                | **Reference**                                                                     | 
-|:-------------------------|:----------------------------------------------------------------------------------|
-| Grafana Agent            | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/grafana-agent-k8s>`        |
-| Mongo DB                 | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/mongodb-k8s>`              |
-| Self-Signed Certificates | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/self-signed-certificates>` |
-| SD-Core AMF              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-amf>`               | 
-| SD-Core AUSF             | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-ausf>`              | 
-| SD-Core Gnbsim           | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-gnbsim>`            | 
-| SD-Core NRF              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-nrf>`               |
-| SD-Core NSSF             | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-nssf>`              |
-| SD-Core PCF              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-pcf>`               |
-| SD-Core Router           | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-router>`            |
-| SD-Core SMF              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-smf>`               |
-| SD-Core UDM              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-udm>`               | 
-| SD-Core UDR              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-udr>`               | 
-| SD-Core UPF              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-upf>`               |
-| SD-Core Webui            | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-webui>`             | 
+| **Charm**                  | **Reference**                                                                        | 
+|:---------------------------|:-------------------------------------------------------------------------------------|
+| Grafana Agent              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/grafana-agent-k8s>`           |
+| Mongo DB                   | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/mongodb-k8s>`                 |
+| Self-Signed Certificates   | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/self-signed-certificates>`    |
+| SD-Core AMF K8s            | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-amf-k8s>`              | 
+| SD-Core AUSF K8s           | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-ausf-k8s>`             | 
+| SD-Core Gnbsim K8s         | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-gnbsim-k8s>`           | 
+| SD-Core NRF K8s            | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-nrf-k8s>`              |
+| SD-Core NSSF K8s           | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-nssf-k8s>`             |
+| SD-Core PCF K8s            | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-pcf-k8s>`              |
+| SD-Core Router K8s         | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-router-k8s>`           |
+| SD-Core SMF K8s            | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-smf-k8s>`              |
+| SD-Core UDM K8s            | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-udm-k8s>`              | 
+| SD-Core UDR K8s            | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-udr-k8s>`              | 
+| SD-Core UPF K8s            | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-upf-k8s>`              |
+| SD-Core Webui K8s          | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-webui-k8s>`            | 

--- a/docs/reference/deployment_options.md
+++ b/docs/reference/deployment_options.md
@@ -4,7 +4,7 @@
     
 ````{tab-item} Single site deployment
 
-Use the `sdcore` bundle to deploy a standalone 5G core network.
+Use the `sdcore-k8s` bundle to deploy a standalone 5G core network.
 This bundle contains the 5G control plane functions, the UPF, Webui, Grafana Agent, Self Signed 
 Certificates and MongoDB.
 
@@ -18,8 +18,8 @@ Certificates and MongoDB.
 
 ````{tab-item} Edge deployment
 
-Use the `sdcore-control-plane` to deploy the 5G control plane in a central place and the 
-`sdcore-user-plane` bundle to deploy the 5G user plane in edge sites.
+Use the `sdcore-control-plane-k8s` to deploy the 5G control plane in a central place and the 
+`sdcore-user-plane-k8s` bundle to deploy the 5G user plane in edge sites.
 
 ```{image} ../images/sdcore_edge.png
 :alt: Edge deployment

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -70,16 +70,16 @@ Create a Juju model named `core`:
 juju add-model core
 ```
 
-Deploy the `sdcore-router` operator:
+Deploy the `sdcore-router-k8s` operator:
 
 ```console
-juju deploy sdcore-router router --trust --channel=edge
+juju deploy sdcore-router-k8s router --trust --channel=edge
 ```
 
-Deploy the `sdcore` charm bundle:
+Deploy the `sdcore-k8s` charm bundle:
 
 ```console
-juju deploy sdcore --trust --channel=edge
+juju deploy sdcore-k8s --trust --channel=edge
 ```
 
 Deploying the core network can take up to 15 minutes. You can validate the status of the
@@ -92,23 +92,23 @@ Model  Controller          Cloud/Region        Version  SLA          Timestamp
 core   microk8s-localhost  microk8s/localhost  3.1.6    unsupported  12:58:34-05:00
 
 App                       Version  Status   Scale  Charm                     Channel        Rev  Address         Exposed  Message
-amf                                active       1  sdcore-amf                edge            57  10.152.183.208  no       
-ausf                               active       1  sdcore-ausf               edge            40  10.152.183.237  no       
-gnbsim                             active       1  sdcore-gnbsim             edge            43  10.152.183.167  no       
-grafana-agent-k8s         0.32.1   waiting      1  grafana-agent-k8s         latest/stable   44  10.152.183.245  no       installing agent
-mongodb-k8s                        active       1  mongodb-k8s               5/edge          36  10.152.183.156  no       Primary
-nms                                active       1  sdcore-nms                edge            26  10.152.183.121  no       
-nrf                                active       1  sdcore-nrf                edge            62  10.152.183.123  no       
-nssf                               active       1  sdcore-nssf               edge            37  10.152.183.165  no       
-pcf                                active       1  sdcore-pcf                edge            32  10.152.183.205  no       
-router                             active       1  sdcore-router             edge            33  10.152.183.49   no       
-self-signed-certificates           active       1  self-signed-certificates  beta            33  10.152.183.153  no       
-smf                                active       1  sdcore-smf                edge            37  10.152.183.147  no       
-traefik-k8s               2.10.4   active       1  traefik-k8s               latest/stable  148  10.0.0.3        no       
-udm                                active       1  sdcore-udm                edge            35  10.152.183.168  no       
-udr                                active       1  sdcore-udr                edge            31  10.152.183.96   no       
-upf                                active       1  sdcore-upf                edge            64  10.152.183.126  no       
-webui                              active       1  sdcore-webui              edge            23  10.152.183.128  no       
+amf                                active       1  sdcore-amf-k8s                edge            57  10.152.183.208  no       
+ausf                               active       1  sdcore-ausf-k8s               edge            40  10.152.183.237  no       
+gnbsim                             active       1  sdcore-gnbsim-k8s             edge            43  10.152.183.167  no       
+grafana-agent-k8s         0.32.1   waiting      1  grafana-agent-k8s             latest/stable   44  10.152.183.245  no       installing agent
+mongodb-k8s                        active       1  mongodb-k8s                   5/edge          36  10.152.183.156  no       Primary
+nms                                active       1  sdcore-nms-k8s                edge            26  10.152.183.121  no       
+nrf                                active       1  sdcore-nrf-k8s                edge            62  10.152.183.123  no       
+nssf                               active       1  sdcore-nssf-k8s               edge            37  10.152.183.165  no       
+pcf                                active       1  sdcore-pcf-k8s                edge            32  10.152.183.205  no       
+router                             active       1  sdcore-router-k8s             edge            33  10.152.183.49   no       
+self-signed-certificates           active       1  self-signed-certificates      beta            33  10.152.183.153  no       
+smf                                active       1  sdcore-smf-k8s                edge            37  10.152.183.147  no       
+traefik-k8s               2.10.4   active       1  traefik-k8s                   latest/stable  148  10.0.0.3        no       
+udm                                active       1  sdcore-udm-k8s                edge            35  10.152.183.168  no       
+udr                                active       1  sdcore-udr-k8s                edge            31  10.152.183.96   no       
+upf                                active       1  sdcore-upf-k8s                edge            64  10.152.183.126  no       
+webui                              active       1  sdcore-webui-k8s              edge            23  10.152.183.128  no       
 
 Unit                         Workload  Agent  Address      Ports  Message
 amf/0*                       active    idle   10.1.182.23         
@@ -132,10 +132,10 @@ webui/0*                     active    idle   10.1.182.33
 
 ## 4. Deploy the 5G simulator
 
-Deploy the `sdcore-gnbsim` operator
+Deploy the `sdcore-gnbsim-k8s` operator
 
 ```console
-juju deploy sdcore-gnbsim gnbsim --trust --channel=edge
+juju deploy sdcore-gnbsim-k8s gnbsim --trust --channel=edge
 ```
 
 Integrate it to the AMF and the NMS:


### PR DESCRIPTION
# Description

Add -k8s as a suffix in both github and Charmhub name to follow [TE042](https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit) . 

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
