### PR TITLE
feat: Fixing links after charm name change

### DIFF
--- a/docs/reference/charms.md
+++ b/docs/reference/charms.md
@@ -2,20 +2,20 @@
 
 Configuration options and specific charm usage instructions are available on each charm's CharmHub page.
 
-| **Charm**                | **Reference**                                                                     | 
+| **Charm**                | **Reference**                                                                     |
 |:-------------------------|:----------------------------------------------------------------------------------|
 | Grafana Agent            | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/grafana-agent-k8s>`        |
 | Mongo DB                 | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/mongodb-k8s>`              |
 | Self-Signed Certificates | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/self-signed-certificates>` |
-| SD-Core AMF              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-amf>`               | 
-| SD-Core AUSF             | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-ausf>`              | 
-| SD-Core Gnbsim           | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-gnbsim>`            | 
-| SD-Core NRF              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-nrf>`               |
-| SD-Core NSSF             | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-nssf>`              |
-| SD-Core PCF              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-pcf>`               |
-| SD-Core Router           | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-router>`            |
-| SD-Core SMF              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-smf>`               |
-| SD-Core UDM              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-udm>`               | 
-| SD-Core UDR              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-udr>`               | 
-| SD-Core UPF              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-upf>`               |
-| SD-Core Webui            | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-webui>`             | 
+| SD-Core AMF              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-amf-k8s>`           |
+| SD-Core AUSF             | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-ausf-k8s>`          |
+| SD-Core Gnbsim           | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-gnbsim-k8s>`        |
+| SD-Core NRF              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-nrf-k8s>`           |
+| SD-Core NSSF             | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-nssf-k8s>`          |
+| SD-Core PCF              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-pcf-k8s>`           |
+| SD-Core Router           | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-router-k8s>`        |
+| SD-Core SMF              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-smf-k8s>`           |
+| SD-Core UDM              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-udm-k8s>`           |
+| SD-Core UDR              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-udr-k8s>`           |
+| SD-Core UPF              | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-upf-k8s>`           |
+| SD-Core Webui            | {bdg-link-primary-line}`CharmHub  <https://charmhub.io/sdcore-webui-k8s>`         |


### PR DESCRIPTION
# Description

With the new names published, the documentation needs to be updated to point to the correct location.

# Checklist:

- [X] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- N/A I have added tests that validate the behaviour of the software
- [X] I validated that new and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- N/A I have bumped the version of the library
