### PR TITLE
chore: Replacing references to edge with beta

### DIFF
--- a/docs/how-to/deploy_sdcore_cups.md
+++ b/docs/how-to/deploy_sdcore_cups.md
@@ -36,7 +36,7 @@ juju add-model control-plane control-plane-cloud
 
 Deploy the control plane bundle.
 ```console
-juju deploy sdcore-control-plane-k8s --trust --channel=edge --overlay control-plane-overlay.yaml
+juju deploy sdcore-control-plane-k8s --trust --channel=beta --overlay control-plane-overlay.yaml
 ```
 
 Expose the integration offer for the AMF N2 interface.
@@ -73,5 +73,5 @@ juju add-model user-plane user-plane-cloud
 Deploy the user plane bundle.
 
 ```console
-juju deploy sdcore-user-plane-k8s --trust --channel=edge --overlay upf-overlay.yaml
+juju deploy sdcore-user-plane-k8s --trust --channel=beta --overlay upf-overlay.yaml
 ```

--- a/docs/how-to/deploy_sdcore_gnbsim.md
+++ b/docs/how-to/deploy_sdcore_gnbsim.md
@@ -20,7 +20,7 @@ juju add-model gnbsim gnbsim-cloud
 Deploy the `sdcore-gnbsim-k8s` operator charm.
 
 ```console
-juju deploy sdcore-gnbsim-k8s gnbsim --trust --channel=edge \
+juju deploy sdcore-gnbsim-k8s gnbsim --trust --channel=beta \
   --config gnb-interface=ran \
   --config gnb-ip-address=10.204.0.10/24 \
   --config icmp-packet-destination=8.8.8.8 \

--- a/docs/how-to/deploy_sdcore_standalone.md
+++ b/docs/how-to/deploy_sdcore_standalone.md
@@ -14,7 +14,7 @@ You will need a Kubernetes cluster installed and configured with Multus.
 ## Deploy
 
 ```bash
-juju deploy sdcore-k8s --trust --channel=edge
+juju deploy sdcore-k8s --trust --channel=beta
 ```
 
 ## Configure

--- a/docs/how-to/deploy_sdcore_user_plane_with_hugepages.md
+++ b/docs/how-to/deploy_sdcore_user_plane_with_hugepages.md
@@ -46,7 +46,7 @@ EOF
 Deploy the `sdcore-user-plane-k8s` bundle.
 
 ```console
-juju deploy sdcore-user-plane-k8s --trust --channel=edge --overlay upf-overlay.yaml
+juju deploy sdcore-user-plane-k8s --trust --channel=beta --overlay upf-overlay.yaml
 ```
 
 ## Validate HugePages support

--- a/docs/how-to/restore_sdcore.md
+++ b/docs/how-to/restore_sdcore.md
@@ -37,5 +37,5 @@ For example, if you deployed the complete SD-Core bundle, you would use the
 following command:
 
 ```bash
-juju deploy sdcore-k8s --trust --channel=edge
+juju deploy sdcore-k8s --trust --channel=beta
 ```

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -73,13 +73,13 @@ juju add-model core
 Deploy the `sdcore-router-k8s` operator:
 
 ```console
-juju deploy sdcore-router-k8s router --trust --channel=edge
+juju deploy sdcore-router-k8s router --trust --channel=beta
 ```
 
 Deploy the `sdcore-k8s` charm bundle:
 
 ```console
-juju deploy sdcore-k8s --trust --channel=edge
+juju deploy sdcore-k8s --trust --channel=beta
 ```
 
 Deploying the core network can take up to 15 minutes. You can validate the status of the
@@ -135,7 +135,7 @@ webui/0*                     active    idle   10.1.182.33
 Deploy the `sdcore-gnbsim-k8s` operator
 
 ```console
-juju deploy sdcore-gnbsim-k8s gnbsim --trust --channel=edge
+juju deploy sdcore-gnbsim-k8s gnbsim --trust --channel=beta
 ```
 
 Integrate it to the AMF and the NMS:

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -225,7 +225,7 @@ juju add-model control-plane control-plane-cluster
 
 Deploy the control plane Juju bundle:
 ```console
-juju deploy sdcore-control-plane-k8s --trust --channel=edge --overlay control-plane-overlay.yaml
+juju deploy sdcore-control-plane-k8s --trust --channel=beta --overlay control-plane-overlay.yaml
 ```
 
 Expose the Software as a Service offer for the AMF.
@@ -300,7 +300,7 @@ juju add-model user-plane user-plane-cluster
 Deploy user plane bundle:
 
 ```console
-juju deploy sdcore-user-plane-k8s --trust --channel=edge --overlay upf-overlay.yaml
+juju deploy sdcore-user-plane-k8s --trust --channel=beta --overlay upf-overlay.yaml
 ```
 
 Now expose the UPF service offering with Juju.
@@ -339,7 +339,7 @@ Deploy the simulator to the gnbsim cluster. The simulator needs to know the foll
 - `upf-subnet`: subnet where the UPFs are located (also called Access network)
 
 ```console
-juju deploy sdcore-gnbsim-k8s gnbsim --channel=edge \
+juju deploy sdcore-gnbsim-k8s gnbsim --channel=beta \
 --config gnb-interface=ran \
 --config gnb-ip-address=10.204.0.10/24 \
 --config icmp-packet-destination=8.8.8.8 \


### PR DESCRIPTION
# Description

Replaces all references to the `edge` channel with `beta` channel, to reflect the fact that Charmed 5G v1 reached Beta.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
