### PR TITLE
feat: TELCO-951: Simplify DNS Configuration

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -14,6 +14,7 @@ Charmhub
 CharmHub
 CIDR
 CNI
+conf
 config
 configmap
 coredns
@@ -72,6 +73,7 @@ N3
 N4
 N6
 netplan
+newgrp
 Nameserver
 nameservers
 NIC
@@ -92,6 +94,7 @@ pdpe
 PDU
 PFCP
 RAN
+resolv
 RDRAND
 Rockcraft
 Ryzen
@@ -101,6 +104,7 @@ sdcore-k8s
 SMF
 subnet
 subnets
+systemd
 TCP
 TLS
 Traefik


### PR DESCRIPTION
# Description

Updates the tutorial to use a single DNS server
enabled directly by the microk8s dns plugin

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- N/A I have added tests that validate the behaviour of the software (but I have tested it)
- N/A I validated that new and existing unit tests pass locally with my changes
- N/A Any dependent changes have been merged and published in downstream modules
- N/A I have bumped the version of the library
