### PR TITLE
feat: Replacing Juju bundle with Terraform module in Deployment Options

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -106,6 +106,7 @@ subnet
 subnets
 systemd
 TCP
+Terraform
 TLS
 Traefik
 UDM

--- a/docs/reference/deployment_options.md
+++ b/docs/reference/deployment_options.md
@@ -4,9 +4,9 @@
     
 ````{tab-item} Single site deployment
 
-Use the `sdcore-k8s` bundle to deploy a standalone 5G core network.
-This bundle contains the 5G control plane functions, the UPF, Webui, Grafana Agent, Self Signed 
-Certificates and MongoDB.
+Use the [sdcore-k8s][sdcore-k8s-terraform] Terraform module to deploy a standalone 5G core network.
+This module contains the 5G control plane functions, the UPF, the NMS (Network Management System), 
+Grafana Agent, Self Signed Certificates and MongoDB.
 
 ```{image} ../images/sdcore_single_site.png
 :alt: Single site deployment
@@ -18,8 +18,9 @@ Certificates and MongoDB.
 
 ````{tab-item} Edge deployment
 
-Use the `sdcore-control-plane-k8s` to deploy the 5G control plane in a central place and the 
-`sdcore-user-plane-k8s` bundle to deploy the 5G user plane in edge sites.
+Use the [sdcore-control-plane-k8s][sdcore-control-plane-k8s] Terraform module to deploy 
+the 5G control plane in a central place and the [sdcore-user-plane-k8s][sdcore-user-plane-k8s] 
+Terraform module to deploy the 5G user plane in edge sites.
 
 ```{image} ../images/sdcore_edge.png
 :alt: Edge deployment
@@ -30,3 +31,7 @@ Use the `sdcore-control-plane-k8s` to deploy the 5G control plane in a central p
 ````
 
 `````
+
+[sdcore-k8s-terraform]: https://github.com/canonical/terraform-juju-sdcore-k8s/tree/main/modules/sdcore-k8s
+[sdcore-control-plane-k8s]: https://github.com/canonical/terraform-juju-sdcore-k8s/tree/main/modules/sdcore-control-plane-k8s
+[sdcore-user-plane-k8s]: https://github.com/canonical/terraform-juju-sdcore-k8s/tree/main/modules/sdcore-user-plane-k8s


### PR DESCRIPTION
# Description

Updates the `Deployment Options` reference to use Terraform modules instead of Juju bundle for Charmed 5G deployment.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
