### PR TITLE
chore: bump juju version to 3.4

### DIFF
--- a/docs/how-to/deploy_sdcore_cups.md
+++ b/docs/how-to/deploy_sdcore_cups.md
@@ -4,7 +4,7 @@ This guide covers how to install a SD-Core 5G core network with Control Plane an
 
 ## Requirements
 
-- Juju >= 3.1
+- Juju >= 3.4
 - A Juju controller has been bootstrapped, and is externally reachable
 - A Control Plane Kubernetes cluster configured with
   - 1 available IP address for the Access and Mobility Management Function (AMF)

--- a/docs/how-to/deploy_sdcore_gnbsim.md
+++ b/docs/how-to/deploy_sdcore_gnbsim.md
@@ -4,7 +4,7 @@ This guide covers how to install and configure the SD-Core gNB Simulator.
 
 ## Requirements
 
-- Juju >= 3.1
+- Juju >= 3.4
 - A Juju controller has been bootstrapped
 - A Kubernetes cluster configured with Multus
 - 1 Juju cloud for the Kubernetes cluster has been added

--- a/docs/how-to/deploy_sdcore_standalone.md
+++ b/docs/how-to/deploy_sdcore_standalone.md
@@ -6,7 +6,7 @@ This guide covers how to install a standalone SD-Core 5G core network, suitable 
 
 You will need a Kubernetes cluster installed and configured with Multus.
 
-- Juju >= 3.1
+- Juju >= 3.4
 - Kubernetes >= 1.25
 - A `LoadBalancer` Service for Kubernetes
 - Multus

--- a/docs/how-to/deploy_sdcore_user_plane_with_hugepages.md
+++ b/docs/how-to/deploy_sdcore_user_plane_with_hugepages.md
@@ -9,7 +9,7 @@ the `sdcore-user-plane` Juju bundle.
   - CPU that supports AVX2, RDRAND and PDPE1GB instructions (Intel Haswell, AMD Excavator or equivalent)
   - LoadBalancer with 1 available address for the UPF
   - Multus CNI enabled
-- Juju >= 3.1/stable
+- Juju >= 3.4/stable
 - A Juju controller bootstrapped onto the Kubernetes host
 - Juju model created, named `user-plane`
 

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -49,7 +49,7 @@ sudo microk8s enable metallb:10.0.0.2-10.0.0.4
 From your terminal, install Juju.
 
 ```console
-sudo snap install juju --channel=3.1/stable
+sudo snap install juju --channel=3.4/stable
 ```
 
 Bootstrap a Juju controller
@@ -197,7 +197,7 @@ for `grafana-agent` to remain in waiting state. Example:
 ```console
 ubuntu@host:~$ juju status
 Model    Controller          Cloud/Region        Version  SLA          Timestamp
-sdcore   microk8s-localhost  microk8s/localhost  3.1.7    unsupported  13:40:12+01:00
+sdcore   microk8s-localhost  microk8s/localhost  3.4.0    unsupported  13:40:12+01:00
 
 App                       Version  Status   Scale  Charm                         Channel             Rev  Address          Exposed  Message
 amf                                active       1  sdcore-amf-k8s                1.3/edge            57   10.152.183.208   no

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -15,8 +15,8 @@ A machine running Ubuntu 22.04 with the following resources:
 
 The following IP networks will be used to connect and isolate the network functions.
 
-| Name | Subnet | Gateway IP |
-| ---- | ------ | ---------- |
+| Name         | Subnet        | Gateway IP |
+| ------------ | ------------- | ---------- |
 | `management` | 10.201.0.0/24 | 10.201.0.1 |
 | `access`     | 10.202.0.0/24 | 10.202.0.1 |
 | `core`       | 10.203.0.0/24 | 10.203.0.1 |
@@ -161,7 +161,7 @@ sudo snap connect multipass:lxd lxd
 To complete this tutorial, you will need seven virtual machines with access to the networks as follows.
 
 | Machine                              | CPUs | RAM | Disk | Networks                       |
-|--------------------------------------|------|-----|------|--------------------------------|
+| ------------------------------------ | ---- | --- | ---- | ------------------------------ |
 | DNS Server                           | 1    | 1g  | 10g  | `management`                   |
 | Control Plane Kubernetes Cluster     | 4    | 8g  | 40g  | `management`                   |
 | User Plane Kubernetes Cluster        | 2    | 4g  | 20g  | `management`, `access`, `core` |
@@ -266,17 +266,17 @@ echo 127.0.0.1 | sudo tee /etc/resolv.conf
 
 The following IP addresses are used in this tutorial and must be present in the DNS Server that all hosts are using.
 
-| Name | IP Address   | Purpose |
-| ---- |--------------| ------- |
-| `juju-controller.mgmt` | 10.201.0.104 | Management address for Juju machine |
-| `control-plane.mgmt` | 10.201.0.101 | Management address for control plane cluster machine |
-| `user-plane.mgmt` | 10.201.0.102 | Management address for user plane cluster machine |
-| `gnbsim.mgmt` | 10.201.0.103 | Management address for the gNB Simulator cluster machine |
-| `api.juju-controller.mgmt` | 10.201.0.50  | Juju controller address |
-| `cos.mgmt` | 10.201.0.51  | Canonical Observability Stack address |
-| `amf.mgmt` | 10.201.0.52  | Externally reachable control plane endpoint for the AMF |
-| `control-plane-nms.control-plane.mgmt` | 10.201.0.53  | Externally reachable control plane endpoint for the NMS |
-| `upf.mgmt` | 10.201.0.200 | Externally reachable control plane endpoint for the UPF |
+| Name                                   | IP Address   | Purpose                                                  |
+| -------------------------------------- | ------------ | -------------------------------------------------------- |
+| `juju-controller.mgmt`                 | 10.201.0.104 | Management address for Juju machine                      |
+| `control-plane.mgmt`                   | 10.201.0.101 | Management address for control plane cluster machine     |
+| `user-plane.mgmt`                      | 10.201.0.102 | Management address for user plane cluster machine        |
+| `gnbsim.mgmt`                          | 10.201.0.103 | Management address for the gNB Simulator cluster machine |
+| `api.juju-controller.mgmt`             | 10.201.0.50  | Juju controller address                                  |
+| `cos.mgmt`                             | 10.201.0.51  | Canonical Observability Stack address                    |
+| `amf.mgmt`                             | 10.201.0.52  | Externally reachable control plane endpoint for the AMF  |
+| `control-plane-nms.control-plane.mgmt` | 10.201.0.53  | Externally reachable control plane endpoint for the NMS  |
+| `upf.mgmt`                             | 10.201.0.200 | Externally reachable control plane endpoint for the UPF  |
 
 Add records under /etc/hosts:
 
@@ -766,11 +766,11 @@ scp user-plane-cluster.yaml juju-controller.mgmt:
 
 In this guide, the following network interfaces are available on the SD-Core `user-plane` VM:
 
-| Interface Name    | Purpose                                                                                                                                                           |
-|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| enp6s0            | internal Kubernetes management interface. This maps to the `management` subnet.                                                                                   |
-| enp7s0            | core interface. This maps to the `core` subnet.                                                                                                                   |
-| enp8s0            | access interface. This maps to the `access` subnet. Note that internet egress is required here and routing tables are already set to route gNB generated traffic. |
+| Interface Name | Purpose                                                                                                                                                           |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| enp6s0         | internal Kubernetes management interface. This maps to the `management` subnet.                                                                                   |
+| enp7s0         | core interface. This maps to the `core` subnet.                                                                                                                   |
+| enp8s0         | access interface. This maps to the `access` subnet. Note that internet egress is required here and routing tables are already set to route gNB generated traffic. |
 
 Now we create the MACVLAN bridges for `enp7s0` and `enp8s0`. These instructions are put into a file that is executed on reboot so the interfaces will come back.
 
@@ -826,9 +826,9 @@ scp gnb-cluster.yaml juju-controller.mgmt:
 In this guide, the following network interfaces are available on the `gnbsim` VM:
 
 | Interface Name | Purpose                                                                         |
-|----------------|---------------------------------------------------------------------------------|
-| enp6s0           | internal Kubernetes management interface. This maps to the `management` subnet. |
-| enp7s0           | ran interface. This maps to the `ran` subnet.                                   |
+| -------------- | ------------------------------------------------------------------------------- |
+| enp6s0         | internal Kubernetes management interface. This maps to the `management` subnet. |
+| enp7s0         | ran interface. This maps to the `ran` subnet.                                   |
 
 Now we create the MACVLAN bridges for `enp7s0`, and label them accordingly:
 
@@ -874,7 +874,7 @@ Install Juju and bootstrap the controller to the local Microk8s install as a loa
 
 ```console
 mkdir -p ~/.local/share/juju
-sudo snap install juju --channel=3.1/stable
+sudo snap install juju --channel=3.4/stable
 juju bootstrap microk8s --config controller-service-type=loadbalancer sdcore
 ```
 


### PR DESCRIPTION
# Description

Bump juju version to 3.4, this will be necessary for using log forwarding.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
