### PR TITLE
chore: Add public clouds reference

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -6,6 +6,7 @@ APIs
 AUSF
 AVX
 balancer
+balancers
 bessd
 br
 Bitrate
@@ -28,6 +29,7 @@ dnsmasq
 DNS
 enp
 gb
+GCP
 Gi
 GiB
 gnb

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -6,4 +6,5 @@
 charms
 deployment_options
 networking
+public_clouds
 ```

--- a/docs/reference/public_clouds.md
+++ b/docs/reference/public_clouds.md
@@ -1,0 +1,5 @@
+# Public Clouds
+
+It is not possible to deploy SD-Core on AWS, Microsoft Azure or GCP using their self-managed Kubernetes services. None of them support SCTP on load balancers, which prevent us from getting all the services up and running.
+
+Microk8s is the preferred Kubernetes distribution for SD-Core.

--- a/docs/reference/public_clouds.md
+++ b/docs/reference/public_clouds.md
@@ -1,5 +1,5 @@
 # Public Clouds
 
-It is not possible to deploy SD-Core on AWS, Microsoft Azure or GCP using their self-managed Kubernetes services. None of them support SCTP on load balancers, which prevent us from getting all the services up and running.
+It is not possible to deploy SD-Core on AWS, Microsoft Azure or GCP using their managed Kubernetes services. None of them support the SCTP protocol on load balancers, which prevents the UPF from communicating with the AMF.
 
 Microk8s is the preferred Kubernetes distribution for SD-Core.


### PR DESCRIPTION
# Description

We cannot deploy SD-Core in public clouds due to the lack of support of SCTP Load Balancers. 
This information is added to documentation as a reference.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
