### PR TITLE
fix: replace UPF by gnb in public cloud documentation

### DIFF
--- a/docs/reference/public_clouds.md
+++ b/docs/reference/public_clouds.md
@@ -1,5 +1,5 @@
 # Public Clouds
 
-It is not possible to deploy SD-Core on AWS, Microsoft Azure or GCP using their managed Kubernetes services. None of them support the SCTP protocol on load balancers, which prevents the UPF from communicating with the AMF.
+It is not possible to deploy SD-Core on AWS, Microsoft Azure or GCP using their managed Kubernetes services. None of them support the SCTP protocol on load balancers, which prevents the gNodeB from communicating with the AMF.
 
 Microk8s is the preferred Kubernetes distribution for SD-Core.


### PR DESCRIPTION
# Description

The gnb is the one that communicates with the AMF.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
